### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 [![Gem Version](https://badge.fury.io/rb/finite_machine.png)][gem]
 [![Build Status](https://secure.travis-ci.org/peter-murach/finite_machine.png?branch=master)][travis]
 [![Code Climate](https://codeclimate.com/github/peter-murach/finite_machine.png)][codeclimate]
+[![Inline docs](http://inch-pages.github.io/github/peter-murach/finite_machine.png)][inchpages]
 
 [gem]: http://badge.fury.io/rb/finite_machine
 [travis]: http://travis-ci.org/peter-murach/finite_machine
 [codeclimate]: https://codeclimate.com/github/peter-murach/finite_machine
+[inchpages]: http://inch-pages.github.io/github/peter-murach/finite_machine
 
 A minimal finite state machine with a straightforward and intuitive syntax. You can quickly model states and add callbacks that can be triggered synchronously or asynchronously.
 


### PR DESCRIPTION
Hi Piotr,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/peter-murach/finite_machine.png)](http://inch-pages.github.io/github/peter-murach/finite_machine)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for FiniteMachine is http://inch-pages.github.io/github/peter-murach/finite_machine/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
