### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ class Car
   def engine
     @engine ||= Engine.new
     @engine.target(self)
+    @engine
   end
 end
 ```


### PR DESCRIPTION
The method DSL#target does not return the associated machine when called.  Instead, it returns the target object.

This PR fixes the documentation for the standalone machine example.
