### PR TITLE
Removes use of class variable to share Sync

### DIFF
--- a/lib/finite_machine.rb
+++ b/lib/finite_machine.rb
@@ -31,6 +31,7 @@ require "finite_machine/subscribers"
 require "finite_machine/state_parser"
 require "finite_machine/observer"
 require "finite_machine/listener"
+require "finite_machine/two_phase_lock"
 
 module FiniteMachine
   # Default state name

--- a/lib/finite_machine/threadable.rb
+++ b/lib/finite_machine/threadable.rb
@@ -4,7 +4,6 @@ module FiniteMachine
   # A mixin to allow instance methods to be synchronized
   module Threadable
     module InstanceMethods
-      @@sync = Sync.new
 
       # Exclusive lock
       #
@@ -12,7 +11,7 @@ module FiniteMachine
       #
       # @api public
       def sync_exclusive(&block)
-        @@sync.synchronize(:EX, &block)
+        TwoPhaseLock.synchronize(:EX, &block)
       end
 
       # Shared lock
@@ -21,7 +20,7 @@ module FiniteMachine
       #
       # @api public
       def sync_shared(&block)
-        @@sync.synchronize(:SH, &block)
+        TwoPhaseLock.synchronize(:SH, &block)
       end
     end
 

--- a/lib/finite_machine/two_phase_lock.rb
+++ b/lib/finite_machine/two_phase_lock.rb
@@ -1,0 +1,14 @@
+
+module FiniteMachine
+  module TwoPhaseLock     
+    def sync
+      @sync ||= Sync.new
+    end
+
+    def synchronize(mode, &block)
+      sync.synchronize(mode, &block)
+    end
+
+    module_function :sync, :synchronize
+  end
+end


### PR DESCRIPTION
Perhaps I'm being pedantic, but I always see the use of a class variables as a red flag.

If a class that inherits from FinteMachine::StateMachine modifies @@sync, every FiniteMachine::StateMachine will be affected by that change.

```
 class FiniteMachine::StateMachine
   def current_sync
      @@sync
   end
 end

 state_machine = FiniteMachine::StateMachine.new

 state_machine.current_sync -----> Instance of Sync

 class OtherStateMachine < FiniteMachine::StateMachine
    @@sync = something_else
 end

 state_machine.current_sync -----> something_else
```
