### PR TITLE
Allows the target method to be aliased within a definition

### DIFF
--- a/lib/finite_machine/dsl.rb
+++ b/lib/finite_machine/dsl.rb
@@ -122,6 +122,24 @@ module FiniteMachine
         machine.env.target = object
       end
     end
+    
+    # Use alternative name for target within definition
+    # 
+    # @example
+    #   target_alias: :car
+    #   
+    #   callbacks {
+    #     on_transition do |event|
+    #       car.state = event.to
+    #     end
+    #   }
+    # 
+    # @param [Symbol] alias_name
+    #
+    # @api public
+    def target_alias(alias_name)
+      FiniteMachine::StateMachine.send(:alias_method, alias_name, :target)
+    end
 
     # Define terminal state
     #

--- a/spec/unit/standalone_with_alias_spec.rb
+++ b/spec/unit/standalone_with_alias_spec.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe FiniteMachine::Definition, 'definition' do
+
+  before do
+    class Engine < FiniteMachine::Definition
+      initial :neutral
+      
+      target_alias :car
+
+      events {
+        event :forward, [:reverse, :neutral] => :one
+        event :shift, :one => :two
+        event :shift, :two => :one
+        event :back,  [:neutral, :one] => :reverse
+      }
+
+      callbacks {
+        on_enter :reverse do |event|
+          car.turn_reverse_lights_on
+        end
+
+        on_exit :reverse do |event|
+          car.turn_reverse_lights_off
+        end
+      }
+
+      handlers {
+        handle FiniteMachine::InvalidStateError do |exception| end
+      }
+    end
+  end
+
+  it "creates unique instances" do
+    engine_a = Engine.new
+    engine_b = Engine.new
+    expect(engine_a).not_to be(engine_b)
+
+    engine_a.forward
+    expect(engine_a.current).to eq(:one)
+    expect(engine_b.current).to eq(:neutral)
+  end
+
+  it "allows to create standalone machine" do
+    Car = Class.new do
+      def turn_reverse_lights_off
+        @reverse_lights = false
+      end
+
+      def turn_reverse_lights_on
+        @reverse_lights = true
+      end
+
+      def reverse_lights?
+        @reverse_lights ||= false
+      end
+    end
+
+    car = Car.new
+    engine = Engine.new
+    engine.target car
+    expect(engine.current).to eq(:neutral)
+
+    engine.forward
+    expect(engine.current).to eq(:one)
+    expect(car.reverse_lights?).to be false
+
+    engine.back
+    expect(engine.current).to eq(:reverse)
+    expect(car.reverse_lights?).to be true
+  end
+end


### PR DESCRIPTION
In my current project, I've separated the finite machine from a host Job model using a FiniteMachine::Definition class. In writing the definition, it has struck me that it would be much more readable if I could alias the target method. Using the example from the README:

``` ruby
class Engine < FiniteMachine::Definition
  initial :neutral

  alias_target :car

  events {
    event :forward, [:reverse, :neutral] => :one
    event :shift, :one => :two
    event :back,  [:neutral, :one] => :reverse
  }

  callbacks {
    on_enter :reverse do |event|
      car.turn_reverse_lights_on
    end

    on_exit :reverse do |event|
      car.turn_reverse_lights_off
    end
  }

  handlers {
    handle FiniteMachine::InvalidStateError do |exception| ... end
  }
end
```

I've implemented a solution that works, but I'm not convinced I'm making the right changes in the right place.
