### PR TITLE
Add test showing different args number for async conditionals

### DIFF
--- a/spec/unit/async_events_spec.rb
+++ b/spec/unit/async_events_spec.rb
@@ -68,6 +68,24 @@ describe FiniteMachine, 'async_events' do
     expect(fsmBar.current).to eql(:yellow)
   end
 
+  it "requires different number of arguments on conditional choices" do
+    fsm = FiniteMachine.define do
+      events {
+        event :go, from: :any do
+          choice :yellow, if: -> (context) { true }
+        end
+      }
+    end
+
+    # sync passes
+    fsm.go
+    fsm.restore!(:green)
+
+    # async logs
+    # Error while running event: wrong number of arguments (2 for 1)
+    fsm.async.go
+  end
+
   it "permits async callback" do
     called = []
     fsm = FiniteMachine.define do


### PR DESCRIPTION
Hi,

I suspect that I'm missing some piece of info / misreading docs and unfortunately, I was not able to figure this out by staring into the code either. Could you please point me to the right direction?

The following test shows a different 'signature' for sync and async event conditons. Is this by design? Or should I just use `-> (*args) { }` and handle the arguments myself?
