### PR TITLE
Fix mistake in ActiveRecord example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,7 @@ class Account < ActiveRecord::Base
       event :authorize, :pending => :access
 
       on_enter do |event|
-        target.state = state
+        target.state = state.to
       end
     end
   end


### PR DESCRIPTION
The `state` here is not a string but an object with a `to` method on it, which returns the state as a string.