### PR TITLE
Rename final to terminal state

### DIFF
--- a/lib/finite_machine/dsl.rb
+++ b/lib/finite_machine/dsl.rb
@@ -122,7 +122,7 @@ module FiniteMachine
     #
     # @api public
     def terminal(*values)
-      self.final_state = values
+      self.terminal_states = values
     end
 
     # Create event and associate transition

--- a/lib/finite_machine/state_machine.rb
+++ b/lib/finite_machine/state_machine.rb
@@ -28,8 +28,8 @@ module FiniteMachine
     # Initial state, defaults to :none
     attr_threadsafe :initial_state
 
-    # Final state, defaults to :none
-    attr_threadsafe :final_state
+    # Final state, defaults to nil
+    attr_threadsafe :terminal_states
 
     # The prefix used to name events.
     attr_threadsafe :namespace
@@ -226,7 +226,7 @@ module FiniteMachine
     #
     # @api public
     def terminated?
-      is?(final_state)
+      is?(terminal_states)
     end
 
     # Restore this machine to a known state


### PR DESCRIPTION
This makes the naming more congruent with `terminal` in the DSL,
which should make it easier discover how to query terminal states.

### Describe the change
Renames `StateMachine#final_state` to `StateMachine#terminal_states`.

### Why are we doing this?
Because the DSL uses the terminology `terminal` to define terminal states. `final_state` is an unnecessary inconsistency that's incongruent with comments, docs, and code.

### Benefits
Less terminology and less inconsistencies for people to deal with.

### Drawbacks
This could be a breaking change for people who are calling `StateMachine#final_state` from their code.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
