### PR TITLE
[CI] update rspec-benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem 'ruby-prof', '~> 0.17.0', platforms: :mri
   gem 'pry',   '~> 0.10.1'
-  gem 'rspec-benchmark', RUBY_VERSION < '2.1.0' ? '~> 0.4' : '~> 0.6'
+  gem 'rspec-benchmark', RUBY_VERSION < "2.1.0" ? "~> 0.4" : "~> 0.6"
 end
 
 group :metrics do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :development do
   gem 'ruby-prof', '~> 0.17.0', platforms: :mri
   gem 'pry',   '~> 0.10.1'
+  gem 'rspec-benchmark', RUBY_VERSION < '2.1.0' ? '~> 0.4' : '~> 0.6'
 end
 
 group :metrics do

--- a/finite_machine.gemspec
+++ b/finite_machine.gemspec
@@ -31,6 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rspec-benchmark", "~> 0.4.0"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
### Describe the change
update rspec-benchmark from -> 0.4 to -> 0.6 on supported rubies

### Why are we doing this?
fixes a failure on ruby-head

<pre>
  1) FiniteMachine performs at least 400 ips
     Failure/Error: expect { fsm.next }.to perform_at_least(400).ips
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # /home/travis/.rvm/gems/ruby-head/gems/rspec-benchmark-0.4.0/lib/rspec/benchmark/iteration_matcher.rb:12:in `initialize'
     # /home/travis/.rvm/gems/ruby-head/gems/rspec-benchmark-0.4.0/lib/rspec/benchmark/matchers.rb:37:in `new'
     # /home/travis/.rvm/gems/ruby-head/gems/rspec-benchmark-0.4.0/lib/rspec/benchmark/matchers.rb:37:in `perform_at_least'
     # ./spec/performance/benchmark_spec.rb:52:in `block (2 levels) in <top (required)>'
</pre>

### Benefits
ci

### Drawbacks
rspec-benchmark 0.5 dropped support for Ruby < 2.1. Note that even Ruby 2.4 is already EOL, maybe you should consider removing support for some EOL rubies.

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[] Documentation updated? (not relevant)
