### PR TITLE
[CI] test latest rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,24 @@ language: ruby
 before_install: "gem install bundler -v '< 2.0'"
 script: bundle exec rake ci
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
-  - jruby-9.2.6.0
+  - jruby-9.2.11.1
   - jruby-head
+  - truffleruby
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.11.1
+    - rvm: truffleruby
   fast_finish: true
 branches:
   only: master


### PR DESCRIPTION
### Describe the change
this PR ensures that travis will automatically test against the latest point release 2.7.**1**
+ add truffleruby to the matrix (allow failures)

### Why are we doing this?
to improve the test suite

### Benefits
to ensure it works on recent ruby versions

### Drawbacks
none

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[] Documentation updated? not relevant
