### PR TITLE
fix deadlock

### DIFF
--- a/lib/finite_machine/message_queue.rb
+++ b/lib/finite_machine/message_queue.rb
@@ -180,7 +180,6 @@ module FiniteMachine
       until @dead
         @mutex.synchronize do
           while @queue.empty?
-            break if @dead
             @not_empty.wait(@mutex)
           end
           event = @queue.pop


### PR DESCRIPTION
### Describe the change
fixes: https://github.com/piotrmurach/finite_machine/issues/64

1/ add an event
2/ shutdown the queue, set @dead = true
3/ process_events doesn't release the mutex via conditional variable, because the queue is already dead
4/ an attempt to add a new event after clearing the queue waits for the lock forever https://github.com/piotrmurach/finite_machine/blob/master/lib/finite_machine/message_queue.rb#L62

spec https://github.com/piotrmurach/finite_machine/blob/master/spec/unit/message_queue_spec.rb#L48

### Why are we doing this?
fix sporadic hangs on jruby

### Benefits
CI

### Drawbacks
what was the original intention?

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[] Documentation updated? not relevant
