### PR TITLE
Fix defining object finalizer in Ruby 3.1 to reference a UUID string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [unreleased] - 2023-05-23
+
+### Fixed
+* Fix a 'callback_queue' exception in Ruby 3.1.1 and higher.
+
 ## [v0.14.0] - 2020-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Change Log
 
-## [unreleased] - 2023-05-23
-
 ### Fixed
-* Fix a 'callback_queue' exception in Ruby 3.1.1 by Vadim Kononov(@vkononov)
+* Fix defining object finalizer in Ruby 3.1 to reference a UUID string. by Vadim Kononov(@vkononov)
 
 ## [v0.14.0] - 2020-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [unreleased] - 2023-05-23
 
 ### Fixed
-* Fix a 'callback_queue' exception in Ruby 3.1.1 and higher.
+* Fix a 'callback_queue' exception in Ruby 3.1.1 by Vadim Kononov(@vkononov)
 
 ## [v0.14.0] - 2020-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ### Fixed
-* Fix defining object finalizer in Ruby 3.1 to reference a UUID string. by Vadim Kononov(@vkononov)
+* Fix defining object finalizer in Ruby 3.1 to reference a UUID string
+  by Vadim Kononov(@vkononov)
 
 ## [v0.14.0] - 2020-09-12
 

--- a/lib/finite_machine/observer.rb
+++ b/lib/finite_machine/observer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
+
 require_relative "async_call"
 require_relative "callable"
 require_relative "hook_event"
@@ -19,6 +20,7 @@ module FiniteMachine
     # @api private
     def cleanup_callback_queue(_id)
       if callback_queue.alive?
+        ObjectSpace.undefine_finalizer(@id)
         callback_queue.shutdown
       end
     rescue MessageQueueDeadError

--- a/lib/finite_machine/observer.rb
+++ b/lib/finite_machine/observer.rb
@@ -53,9 +53,9 @@ module FiniteMachine
     def callback_queue
       return @callback_queue if instance_variable_defined?(:@callback_queue)
 
-      @callback_queue = MessageQueue.new
       @object_id = SecureRandom.uuid
       ObjectSpace.define_finalizer(@object_id, cleanup_callback_queue)
+      @callback_queue = MessageQueue.new
     end
 
     # Evaluate in current context


### PR DESCRIPTION
### Describe the change
Fixes the "undefined local variable or method `callback_queue' for FiniteMachine::Observer:Class (NameError)" exception thrown in Ruby 3.1.1

### Why are we doing this?
In Ruby 3.1.1, accessing callback_queue from a finalizer causes a "undefined local variable or method `callback_queue' for FiniteMachine::Observer:Class (NameError)", and callback_queue is never cleaned up. However, making the finalizer an instance method rather than a class method throws a warning about improper use of finalizers.

The fix is borrowed from a Github issue found at https://github.com/appsignal/rdkafka-ruby/pull/160/files.

### Benefits
This library will become compatible with Ruby 3.1.1.

### Drawbacks
None.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [x] Changelog updated?
