### PR TITLE
Make the state hash fully thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   by Vadim Kononov(@vkononov)
 * Fix message queue shutdown to raise valid error
 * Fix any_event and any_state methods in the define method and definition class
+* Fix hooks_map initialization to be fully thread-safe
+  by Maciej Mensfeld(@mensfeld)
 
 ## [v0.14.0] - 2020-09-12
 


### PR DESCRIPTION
Fixes issue described here: https://github.com/ruby-concurrency/concurrent-ruby/issues/970

### Describe the change

Makes the state hash thread-safe

### Why are we doing this?

Because the author (you) may not be aware about a potential race condition here.

### Benefits

One less thing to worry about in case ppl use it heavily from the require moment in multiple threads.

### Drawbacks

Hard to debug issues. Took me weeks to stop it in Karafka.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally? (no)
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated? (no need)
- [x] Changelog updated? (no need - no API changes)
